### PR TITLE
feat: sync minicart total with backend and fix incorrect total rendering

### DIFF
--- a/farmaoffers_theme/__manifest__.py
+++ b/farmaoffers_theme/__manifest__.py
@@ -74,6 +74,7 @@
             "farmaoffers_theme/static/src/snippets/t_owl_carousel/000.js",
             "farmaoffers_theme/static/src/js/checkout_pickup_toggle.js",
             "farmaoffers_theme/static/src/js/mobile_menu.js",
+            "farmaoffers_theme/static/src/js/cart_total_sync.js",
         ],
     },
     "installable": True,

--- a/farmaoffers_theme/controllers/main.py
+++ b/farmaoffers_theme/controllers/main.py
@@ -102,3 +102,25 @@ class FarmaoffersAllOffers(http.Controller):
     @http.route('/all-offers', auth='public', type='http', methods=['GET'], website=True, sitemap=False)
     def allOffers(self, **kw):
         return http.request.render('farmaoffers_theme.all-offers')
+    
+class FarmaoffersCartHeaderController(http.Controller):
+
+    @http.route('/shop/cart/header_info', type='json', auth='public', website=True)
+    def cart_header_info(self):
+        order = request.website.sale_get_order()
+
+        if not order:
+            currency = request.website.currency_id
+            return {
+                'quantity': 0,
+                'amount_total': 0.0,
+                'amount_total_formatted': f'{currency.symbol} 0.00',
+            }
+
+        currency = order.pricelist_id.currency_id or request.website.currency_id
+
+        return {
+            'quantity': order.cart_quantity,
+            'amount_total': order.amount_total,
+            'amount_total_formatted': f'{currency.symbol} {order.amount_total:.2f}',
+        }

--- a/farmaoffers_theme/static/src/js/cart_total_sync.js
+++ b/farmaoffers_theme/static/src/js/cart_total_sync.js
@@ -1,0 +1,80 @@
+/** @odoo-module **/
+
+import publicWidget from "@web/legacy/js/public/public_widget";
+import { rpc } from "@web/core/network/rpc";
+
+publicWidget.registry.FarmaoffersCartTotalSync = publicWidget.Widget.extend({
+    selector: '.minicart-header',
+
+    start() {
+        if (window.__farmaoffersCartSyncInitialized) {
+            return this._super(...arguments);
+        }
+        window.__farmaoffersCartSyncInitialized = true;
+
+        this._boundClickHandler = this._onBodyClick.bind(this);
+        document.body.addEventListener("click", this._boundClickHandler);
+
+        return this._super(...arguments);
+    },
+
+    destroy() {
+        if (this._boundClickHandler) {
+            document.body.removeEventListener("click", this._boundClickHandler);
+        }
+        return this._super(...arguments);
+    },
+
+    async _onBodyClick(ev) {
+        const addToCartBtn = ev.target.closest(
+            'a[href*="/shop/cart/update"], form[action*="/shop/cart/update"] button, .a-submit, #add_to_cart, .o_we_buy_now, .js_check_product, .js_add_cart_json'
+        );
+
+        if (!addToCartBtn) {
+            return;
+        }
+
+        let previousQty = null;
+
+        try {
+            previousQty = await rpc("/shop/cart/header_info", {});
+        } catch (error) {
+            console.error("[CartSync] Error reading previous header info:", error);
+        }
+
+        setTimeout(async () => {
+            let newInfo = null;
+
+            try {
+                newInfo = await rpc("/shop/cart/header_info", {});
+            } catch (error) {
+                console.error("[CartSync] Error reading new header info:", error);
+            }
+
+            if (!previousQty || !newInfo) {
+                return;
+            }
+
+            if (previousQty.quantity === newInfo.quantity) {
+                return;
+            }
+
+            this._updateMiniCart(newInfo);
+        }, 1000);
+    },
+
+    _updateMiniCart(info) {
+        if (!info) {
+            return;
+        }
+
+        document.querySelectorAll(".my_cart_quantity").forEach((el) => {
+            el.textContent = info.quantity ?? 0;
+        });
+
+        document.querySelectorAll(".my_cart_total").forEach((el) => {
+            el.textContent = info.amount_total_formatted ?? "0.00";
+        });
+
+    },
+});

--- a/farmaoffers_theme/views/header.xml
+++ b/farmaoffers_theme/views/header.xml
@@ -188,7 +188,7 @@
                                                     <span>ítem</span>
                                                     <hr class="hr-price" />
                                                     <span class="price-minicart fw-bold">
-                                                        <span class="price">
+                                                        <span class="price my_cart_total">
                                                             <t t-if="website_sale_order.amount_total > 0">
                                                                 <span t-field="website_sale_order.amount_total" t-options='{"widget": "monetary", "display_currency": website_sale_order.pricelist_id.currency_id}' />
                                                             </t>
@@ -311,7 +311,7 @@
                                                         <span>ítem</span>
                                                         <hr class="hr-price" />
                                                         <span class="price-minicart fw-bold">
-                                                            <span class="price">
+                                                            <span class="price my_cart_total">
                                                                 <t t-if="website_sale_order.amount_total > 0">
                                                                     <span t-field="website_sale_order.amount_total" t-options='{"widget": "monetary", "display_currency": website_sale_order.pricelist_id.currency_id}' />
                                                                 </t>
@@ -370,7 +370,7 @@
                                                         </div>
                                                         <hr class="hr-price" />
                                                         <span class="price-minicart">
-                                                            <span class="price">
+                                                            <span class="price my_cart_total">
                                                                 <t t-if="website_sale_order.amount_total > 0">
                                                                     <span t-field="website_sale_order.amount_total" t-options='{"widget": "monetary", "display_currency": website_sale_order.pricelist_id.currency_id}' />
                                                                 </t>


### PR DESCRIPTION
add custom endpoint /shop/cart/header_info to return cart quantity and total
update minicart total dynamically without full page refresh
prevent incorrect total parsing from /shop/cart HTML
avoid UI update when cart quantity does not change
fix duplicated widget initialization
ensure clean currency formatting (no HTML in response)